### PR TITLE
Endpoint comparison error

### DIFF
--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -146,6 +146,8 @@ extension Endpoint: Equatable, Hashable {
             case (let .uploadMultipart(multipartData1), let .uploadMultipart(multipartData2)),
                  (let .uploadCompositeMultipart(multipartData1, _), let .uploadCompositeMultipart(multipartData2, _)):
                 return multipartData1 == multipartData2
+            case (let .requestParameters(lhsParameters, _), let .requestParameters(rhsParameters, _)):
+                return lhsParameters as NSDictionary == rhsParameters as NSDictionary
             default:
                 return true
             }


### PR DESCRIPTION
# Fix

- Add an additional comparison for the endpoint equatable functions, that allows the requestParameters to be taken in consideration
- This was inspired by the fact that two similar (but not equal) request could be ignored by each other.